### PR TITLE
Release notes model

### DIFF
--- a/app/controllers/releases_controller.rb
+++ b/app/controllers/releases_controller.rb
@@ -89,20 +89,12 @@ class ReleasesController < ApplicationController
   # Set a placeholder for forms
   def placeholder(app)
     if @last_release.present?
-      @placeholder = "Current Version: " + Release.version(app, @last_release)
+      @placeholder = 'Current Version: ' + Release.version(app, @last_release)
     end
   end
   helper_method :placeholder
 
   def load_release_notes
-    @release_notes = ""
-    @release_notes << "#My Sage One " + Release.release_notes('mysageone_uk', Release.version('mysageone',@release)) + "\n" if @release.mysageone.present?
-    @release_notes << "#Accounts " + Release.release_notes('sage_one_accounts_uk', Release.version('accounts',@release)) + "\n" if @release.accounts.present?
-    @release_notes << "#Accounts Extra " + Release.release_notes('sage_one_advanced', Release.version('accounts_extra',@release)) + "\n" if @release.accounts_extra.present?
-    @release_notes << "#Payroll " + Release.release_notes('sage_one_payroll_ukie', Release.version('payroll',@release)) + "\n" if @release.payroll.present?
-    @release_notes << "#Addons " + Release.release_notes('sage_one_addons_uk', Release.version('addons',@release)) + "\n" if @release.addons.present?
-    @release_notes << "#Collaborate " + Release.release_notes('chorizo', Release.version('collaborate',@release)) if @release.collaborate.present?
-    @release_notes << "#Accountant Edition " + Release.release_notes('new_accountant_edition', Release.version('accountant_edition',@release)) if @release.accountant_edition.present?
-    @release_notes << "#Accounts Production " + Release.release_notes('sageone_accounts_production', Release.version('accounts_production',@release)) if @release.accounts_production.present?
+    @release_notes = Release.build_release_notes(@release)
   end
 end

--- a/app/controllers/releases_controller.rb
+++ b/app/controllers/releases_controller.rb
@@ -95,6 +95,6 @@ class ReleasesController < ApplicationController
   helper_method :placeholder
 
   def load_release_notes
-    @release_notes = Release.build_release_notes(@release)
+    @release_notes = ReleaseNote.build_release_notes(@release)
   end
 end

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -2,8 +2,9 @@ class Release < ActiveRecord::Base
   attr_accessible :accounts, :accounts_extra, :addons,
     :date, :help, :mysageone,
     :notes, :payroll, :status, :coordinator,
-    :collaborate, :accountant_edition, :accounts_production,
-    :release_notes
+    :collaborate, :accountant_edition, :accounts_production
+
+  has_one :release_note
 
   validates_presence_of :date
   before_save :set_coordinator
@@ -41,70 +42,4 @@ class Release < ActiveRecord::Base
     end
   end
 
-  def self.retrieve_release_notes(repo, version)
-    case repo
-    when 'mysageone_uk'
-      path = 'RELEASENOTES.md'
-      split = '# Version '
-    when 'sage_one_accounts_uk'
-      path = 'RELEASE_NOTES.md'
-      split = '# Release '
-    when 'sage_one_advanced'
-      path = 'RELEASE_NOTES.md'
-      split = '# Version '
-    when 'sage_one_payroll_ukie'
-      path = 'RELEASENOTES.txt'
-      split = 'Release '
-    when 'sage_one_addons_uk'
-      path = "RELEASE_NOTES.md"
-      split = "Version "
-    when 'chorizo'
-      path = 'RELEASENOTES.txt'
-      split = 'Version '
-    when 'new_accountant_edition'
-      path = 'RELEASENOTES.md'
-      split = 'Version '
-    when 'sageone_accounts_production'
-      path = 'ReleaseNotes.txt'
-      split = 'Version '
-    else
-      path = "RELEASENOTES.md"
-      split = "# Version "
-    end
-
-    begin
-      release_notes = Octokit.contents("Sage/#{repo}", :path => path).content
-      release_notes = Base64.decode64(release_notes)
-      release_notes.split(split).keep_if { |r| r.include?("#{version}\n") }[0].to_s
-    rescue
-      return 'Could not retrieve release notes. Try again later.'
-    end
-  end
-
-  def self.build_release_notes(release)
-    return release.release_notes if release.release_notes.present? && release.status == 'Production'
-
-    mysageone = Release.retrieve_release_notes('mysageone_uk', Release.version('mysageone',release)) + "\n" if release.mysageone.present?
-    accounts = Release.retrieve_release_notes('sage_one_accounts_uk', Release.version('accounts',release)) + "\n" if release.accounts.present?
-    accounts_extra = Release.retrieve_release_notes('sage_one_advanced', Release.version('accounts_extra',release)) + "\n" if release.accounts_extra.present?
-    payroll = Release.retrieve_release_notes('sage_one_payroll_ukie', Release.version('payroll',release)) + "\n" if release.payroll.present?
-    addons = Release.retrieve_release_notes('sage_one_addons_uk', Release.version('addons',release)) + "\n" if release.addons.present?
-    collaborate = Release.retrieve_release_notes('chorizo', Release.version('collaborate',release)) + "\n" if release.collaborate.present?
-    accountant_edition = Release.retrieve_release_notes('new_accountant_edition', Release.version('accountant_edition',release)) + "\n" if release.accountant_edition.present?
-    accounts_production = Release.retrieve_release_notes('sageone_accounts_production', Release.version('accounts_production',release)) + "\n" if release.accounts_production.present?
-
-    release_notes = ''
-    release_notes << '####My Sage One ' + (mysageone.present? ? mysageone : "\n No release notes found for this version \n")
-    release_notes << '####Accounts ' + (accounts.present? ? accounts : "\n No release notes found for this version \n")
-    release_notes << '####Accounts Extra ' + (accounts_extra.present? ? accounts_extra : "\n No release notes found for this version \n")
-    release_notes << '####Payroll ' + (payroll.present? ? payroll : "\n No release notes found for this version \n")
-    release_notes << '####Addons ' + (addons.present? ? addons : "\n No release notes found for this version \n")
-    release_notes << '####Collaborate ' + (collaborate.present? ? collaborate : "\n No release notes found for this version \n")
-    release_notes << '####Accountants Edition ' + (accountant_edition.present? ? accountant_edition : "\n No release notes found for this version \n")
-    release_notes << '####Accounts Production ' + (accounts_production.present? ? accounts_production : "\n No release notes found for this version \n")
-
-    release_notes.gsub! '### ', '##### '
-    release.update_attribute(:release_notes, release_notes)
-    return release_notes
-  end
 end

--- a/app/models/release.rb
+++ b/app/models/release.rb
@@ -2,7 +2,8 @@ class Release < ActiveRecord::Base
   attr_accessible :accounts, :accounts_extra, :addons,
     :date, :help, :mysageone,
     :notes, :payroll, :status, :coordinator,
-    :collaborate, :accountant_edition, :accounts_production
+    :collaborate, :accountant_edition, :accounts_production,
+    :release_notes
 
   validates_presence_of :date
   before_save :set_coordinator
@@ -28,7 +29,7 @@ class Release < ActiveRecord::Base
   end
 
   def set_coordinator
-    self.coordinator = "Russell Craxford" if self.coordinator.blank?
+    self.coordinator = 'Russell Craxford' if self.coordinator.blank?
   end
 
   def self.sop_version(repo, version)
@@ -40,40 +41,70 @@ class Release < ActiveRecord::Base
     end
   end
 
-  def self.release_notes(repo, version)
+  def self.retrieve_release_notes(repo, version)
     case repo
-    when "mysageone_uk"
+    when 'mysageone_uk'
+      path = 'RELEASENOTES.md'
+      split = '# Version '
+    when 'sage_one_accounts_uk'
+      path = 'RELEASE_NOTES.md'
+      split = '# Release '
+    when 'sage_one_advanced'
+      path = 'RELEASE_NOTES.md'
+      split = '# Version '
+    when 'sage_one_payroll_ukie'
+      path = 'RELEASENOTES.txt'
+      split = 'Release '
+    when 'sage_one_addons_uk'
+      path = "RELEASE_NOTES.md"
+      split = "Version "
+    when 'chorizo'
+      path = 'RELEASENOTES.txt'
+      split = 'Version '
+    when 'new_accountant_edition'
+      path = 'RELEASENOTES.md'
+      split = 'Version '
+    when 'sageone_accounts_production'
+      path = 'ReleaseNotes.txt'
+      split = 'Version '
+    else
       path = "RELEASENOTES.md"
       split = "# Version "
-    when "sage_one_accounts_uk"
-      path = "RELEASE_NOTES.md"
-      split = "# Release "
-    when "sage_one_advanced"
-      path = "RELEASE_NOTES.md"
-      split = "# Version "
-    when "sage_one_payroll_ukie"
-      path = "RELEASENOTES.txt"
-      split = "Release "
-    when "sage_one_addons_uk"
-      path = "RELEASE_NOTES.md"
-      split = "Version "
-    when "chorizo"
-      path = "RELEASENOTES.txt"
-      split = "Version "
-    when "new_accountant_edition"
-      path = "RELEASENOTES.md"
-      split = "Version "
-    when "sageone_accounts_production"
-      path = "ReleaseNotes.txt"
-      split = "Version "
     end
 
     begin
       release_notes = Octokit.contents("Sage/#{repo}", :path => path).content
       release_notes = Base64.decode64(release_notes)
-      release_notes.split(split).keep_if { |r| r.include?("#{version}") }[0].to_s
+      release_notes.split(split).keep_if { |r| r.include?("#{version}\n") }[0].to_s
     rescue
-      "?"
+      return 'Could not retrieve release notes. Try again later.'
     end
+  end
+
+  def self.build_release_notes(release)
+    return release.release_notes if release.release_notes.present? && release.status == 'Production'
+
+    mysageone = Release.retrieve_release_notes('mysageone_uk', Release.version('mysageone',release)) + "\n" if release.mysageone.present?
+    accounts = Release.retrieve_release_notes('sage_one_accounts_uk', Release.version('accounts',release)) + "\n" if release.accounts.present?
+    accounts_extra = Release.retrieve_release_notes('sage_one_advanced', Release.version('accounts_extra',release)) + "\n" if release.accounts_extra.present?
+    payroll = Release.retrieve_release_notes('sage_one_payroll_ukie', Release.version('payroll',release)) + "\n" if release.payroll.present?
+    addons = Release.retrieve_release_notes('sage_one_addons_uk', Release.version('addons',release)) + "\n" if release.addons.present?
+    collaborate = Release.retrieve_release_notes('chorizo', Release.version('collaborate',release)) + "\n" if release.collaborate.present?
+    accountant_edition = Release.retrieve_release_notes('new_accountant_edition', Release.version('accountant_edition',release)) + "\n" if release.accountant_edition.present?
+    accounts_production = Release.retrieve_release_notes('sageone_accounts_production', Release.version('accounts_production',release)) + "\n" if release.accounts_production.present?
+
+    release_notes = ''
+    release_notes << '####My Sage One ' + (mysageone.present? ? mysageone : "\n No release notes found for this version \n")
+    release_notes << '####Accounts ' + (accounts.present? ? accounts : "\n No release notes found for this version \n")
+    release_notes << '####Accounts Extra ' + (accounts_extra.present? ? accounts_extra : "\n No release notes found for this version \n")
+    release_notes << '####Payroll ' + (payroll.present? ? payroll : "\n No release notes found for this version \n")
+    release_notes << '####Addons ' + (addons.present? ? addons : "\n No release notes found for this version \n")
+    release_notes << '####Collaborate ' + (collaborate.present? ? collaborate : "\n No release notes found for this version \n")
+    release_notes << '####Accountants Edition ' + (accountant_edition.present? ? accountant_edition : "\n No release notes found for this version \n")
+    release_notes << '####Accounts Production ' + (accounts_production.present? ? accounts_production : "\n No release notes found for this version \n")
+
+    release_notes.gsub! '### ', '##### '
+    release.update_attribute(:release_notes, release_notes)
+    return release_notes
   end
 end

--- a/app/models/release_note.rb
+++ b/app/models/release_note.rb
@@ -1,0 +1,78 @@
+class ReleaseNote < ActiveRecord::Base
+  attr_accessible :release_id, :release_notes
+  belongs_to :release
+
+  def self.retrieve_release_notes(repo, version)
+    case repo
+    when 'mysageone_uk'
+      path = 'RELEASENOTES.md'
+      split = '# Version '
+    when 'sage_one_accounts_uk'
+      path = 'RELEASE_NOTES.md'
+      split = '# Release '
+    when 'sage_one_advanced'
+      path = 'RELEASE_NOTES.md'
+      split = '# Version '
+    when 'sage_one_payroll_ukie'
+      path = 'RELEASENOTES.txt'
+      split = 'Release '
+    when 'sage_one_addons_uk'
+      path = "RELEASE_NOTES.md"
+      split = "Version "
+    when 'chorizo'
+      path = 'RELEASENOTES.txt'
+      split = 'Version '
+    when 'new_accountant_edition'
+      path = 'RELEASENOTES.md'
+      split = 'Version '
+    when 'sageone_accounts_production'
+      path = 'ReleaseNotes.txt'
+      split = 'Version '
+    else
+      path = "RELEASENOTES.md"
+      split = "# Version "
+    end
+
+    begin
+      release_notes = Octokit.contents("Sage/#{repo}", :path => path).content
+      release_notes = Base64.decode64(release_notes)
+      release_notes.split(split).keep_if { |r| r.include?("#{version}\n") }[0].to_s
+    rescue
+      return 'Could not retrieve release notes. Try again later.'
+    end
+  end
+
+  def self.build_release_notes(release)
+    return release.release_note if release.release_note.present? && release.status == 'Production'
+
+    mysageone = retrieve_release_notes('mysageone_uk', Release.version('mysageone',release)) + "\n" if release.mysageone.present?
+    accounts = retrieve_release_notes('sage_one_accounts_uk', Release.version('accounts',release)) + "\n" if release.accounts.present?
+    accounts_extra = retrieve_release_notes('sage_one_advanced', Release.version('accounts_extra',release)) + "\n" if release.accounts_extra.present?
+    payroll = retrieve_release_notes('sage_one_payroll_ukie', Release.version('payroll',release)) + "\n" if release.payroll.present?
+    addons = retrieve_release_notes('sage_one_addons_uk', Release.version('addons',release)) + "\n" if release.addons.present?
+    collaborate = retrieve_release_notes('chorizo', Release.version('collaborate',release)) + "\n" if release.collaborate.present?
+    accountant_edition = retrieve_release_notes('new_accountant_edition', Release.version('accountant_edition',release)) + "\n" if release.accountant_edition.present?
+    accounts_production = retrieve_release_notes('sageone_accounts_production', Release.version('accounts_production',release)) + "\n" if release.accounts_production.present?
+
+    release_notes = ''
+    release_notes << '####My Sage One ' + mysageone if mysageone.present?
+    release_notes << '####Accounts ' + accounts if accounts.present?
+    release_notes << '####Accounts Extra ' + accounts_extra if accounts_extra.present?
+    release_notes << '####Payroll ' + payroll if payroll.present?
+    release_notes << '####Addons ' + addons if addons.present?
+    release_notes << '####Collaborate ' + collaborate if collaborate.present?
+    release_notes << '####Accountants Edition ' + accountant_edition if accountant_edition.present?
+    release_notes << '####Accounts Production ' + accounts_production if accounts_production.present?
+
+    release_notes.gsub! '### ', '##### '
+
+    self.first_or_initialize(release_id: release.id).update_attribute(:release_notes, release_notes)
+
+    if release_notes.present?
+      release_notes
+    else
+      "There are no release notes ready yet. Check back later."
+    end
+  end
+
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -33,7 +33,7 @@ Versionkeeper::Application.configure do
   config.assets.compress = false
 
   # Expands the lines which load the assets
-  config.assets.debug = true
+  config.assets.debug = false
 
   config.action_mailer.default_url_options = { :host => 'localhost:3000' }
 

--- a/db/migrate/20140814181745_add_release_notes_to_releases.rb
+++ b/db/migrate/20140814181745_add_release_notes_to_releases.rb
@@ -1,0 +1,5 @@
+class AddReleaseNotesToReleases < ActiveRecord::Migration
+  def change
+    add_column :releases, :release_notes, :text
+  end
+end

--- a/db/migrate/20140821184626_create_release_notes.rb
+++ b/db/migrate/20140821184626_create_release_notes.rb
@@ -1,0 +1,14 @@
+class CreateReleaseNotes < ActiveRecord::Migration
+  def change
+    create_table :release_notes do |t|
+      t.integer :release_id, index: true
+      t.text :release_notes
+      t.timestamps
+    end
+
+    remove_column :releases, :user_id
+    remove_column :releases, :release_notes
+
+    drop_table :users
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,14 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20140814181745) do
+ActiveRecord::Schema.define(:version => 20140821184626) do
+
+  create_table "release_notes", :force => true do |t|
+    t.integer  "release_id"
+    t.text     "release_notes"
+    t.datetime "created_at",    :null => false
+    t.datetime "updated_at",    :null => false
+  end
 
   create_table "releases", :force => true do |t|
     t.string   "accounts"
@@ -25,41 +32,10 @@ ActiveRecord::Schema.define(:version => 20140814181745) do
     t.text     "notes",               :limit => 255
     t.datetime "created_at",                                            :null => false
     t.datetime "updated_at",                                            :null => false
-    t.integer  "user_id"
     t.string   "status",                             :default => "UAT"
     t.string   "coordinator"
     t.string   "accountant_edition"
     t.string   "accounts_production"
-    t.text     "release_notes"
   end
-
-  create_table "users", :force => true do |t|
-    t.string   "email",                  :default => "", :null => false
-    t.string   "encrypted_password",     :default => "", :null => false
-    t.string   "reset_password_token"
-    t.datetime "reset_password_sent_at"
-    t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          :default => 0
-    t.datetime "current_sign_in_at"
-    t.datetime "last_sign_in_at"
-    t.string   "current_sign_in_ip"
-    t.string   "last_sign_in_ip"
-    t.string   "confirmation_token"
-    t.datetime "confirmed_at"
-    t.datetime "confirmation_sent_at"
-    t.string   "unconfirmed_email"
-    t.integer  "failed_attempts",        :default => 0
-    t.string   "unlock_token"
-    t.datetime "locked_at"
-    t.string   "authentication_token"
-    t.datetime "created_at",                             :null => false
-    t.datetime "updated_at",                             :null => false
-  end
-
-  add_index "users", ["authentication_token"], :name => "index_users_on_authentication_token", :unique => true
-  add_index "users", ["confirmation_token"], :name => "index_users_on_confirmation_token", :unique => true
-  add_index "users", ["email"], :name => "index_users_on_email", :unique => true
-  add_index "users", ["reset_password_token"], :name => "index_users_on_reset_password_token", :unique => true
-  add_index "users", ["unlock_token"], :name => "index_users_on_unlock_token", :unique => true
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20140703192006) do
+ActiveRecord::Schema.define(:version => 20140814181745) do
 
   create_table "releases", :force => true do |t|
     t.string   "accounts"
@@ -30,6 +30,7 @@ ActiveRecord::Schema.define(:version => 20140703192006) do
     t.string   "coordinator"
     t.string   "accountant_edition"
     t.string   "accounts_production"
+    t.text     "release_notes"
   end
 
   create_table "users", :force => true do |t|

--- a/spec/factories/releases.rb
+++ b/spec/factories/releases.rb
@@ -10,8 +10,9 @@ FactoryGirl.define do
     collaborate '1.0'
     help '1.0'
     addons '1.0'
-    notes 'Release Notes'
+    notes 'Notes'
     status 'UAT'
+    release_notes 'Release Notes'
   end
 
   factory :release_without_status, class: Release do
@@ -23,8 +24,9 @@ FactoryGirl.define do
     collaborate '1.0'
     help '1.0'
     addons '1.0'
-    notes 'Release Notes'
+    notes 'Notes'
     status 'UAT'
+    release_notes 'Release Notes'
   end
 
   factory :release_only_date, class: Release do

--- a/spec/factories/releases.rb
+++ b/spec/factories/releases.rb
@@ -12,7 +12,6 @@ FactoryGirl.define do
     addons '1.0'
     notes 'Notes'
     status 'UAT'
-    release_notes 'Release Notes'
   end
 
   factory :release_without_status, class: Release do
@@ -26,7 +25,6 @@ FactoryGirl.define do
     addons '1.0'
     notes 'Notes'
     status 'UAT'
-    release_notes 'Release Notes'
   end
 
   factory :release_only_date, class: Release do

--- a/spec/models/release_notes_spec.rb
+++ b/spec/models/release_notes_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+describe ReleaseNote do
+  subject { ReleaseNote }
+
+  describe :retrieve_release_notes do
+    before :each do
+      mysageone_uk_release_notes = Base64.encode64("# Version 2.15\n\n### Changes\n  * Allowing business access whilst business owner is blocked does not re-activated Zuora subscription [UKIEBUGS-366] (https://sageone.atlassian.net/browse/UKIEBUGS-366)\n  * Begin Rescue block when uploading mandate CSV to S3\n  * Fixes bug where client can not add new services if they only have collaborate [UKIEBUGS-322] (https://sageone.atlassian.net/browse/UKIEBUGS-322)\n  * Small change to remove variable assignment from rake datafixes:null_zuora_subscriptions\n  * Validate UK Bank Account Number on DD Form [UKIEBUGS-395] (https://sageone.atlassian.net/browse/UKIEBUGS-395)\n\n### Dependencies\n  * None\n\n### Deploy tasks\n  * None\n\n# Version 2.14.1\n\n### Changes\n  * Adding 'piwik' (new open source alternative to google analytics) tracking codes\n\n### Dependencies\n  * None\n\n### Deploy tasks\n  * None\n\n# Version 2.14\n\n### Changes\n  * Fixes Duplicate charges in Zuora after account un blocked [UKIEBUGS-138] (https://sageone.atlassian.net/browse/UKIEBUGS-138)\n  * Fixes calculation of next chargable date [UKIEBUGS-299] (https://sageone.atlassian.net/browse/UKIEBUGS-299)\n  * Fixes bug relating to downgrade from standard to cashbook with JWT [UKIEBUGS-315] (https://sageone.atlassian.net/browse/UKIEBUGS-315)\n  * Fixes bug relating to upgrade from Cashbook to Accounts when previously had the service [UKIEBUGS-318] (https://sageone.atlassian.net/browse/UKIEBUGS-318)\n  * Fixes bug relating to downgrading to Accounts when has previously has Cashbook and Accounts Extra via JWT [UKIEBUGS-321] (https://sageone.atlassian.net/browse/UKIEBUGS-321)\n  * Resolve an issue with Zuora subscription by running null_zuora_subscriptions rake task [UKIEBUGS-314] (https://sageone-uat.sageone.biz/browse/UKIEBUGS-314)\n  * Adding 'piwik' (new open source alternative to google analytics) tracking codes\n\n### Dependencies\n  * None\n\n### Deploy tasks\n  * bundle exec rake datafixes:null_zuora_subscriptions['ca8b06cd3c23ea14f69dd816f90621c1']\n\n#")
+
+      Octokit.stub_chain('contents','content').and_return(mysageone_uk_release_notes)
+    end
+
+    it "returns release notes for the given repo and version" do
+      expect(subject.retrieve_release_notes('mysageone_uk','2.14.1')).to eq("2.14.1\n\n### Changes\n  * Adding 'piwik' (new open source alternative to google analytics) tracking codes\n\n### Dependencies\n  * None\n\n### Deploy tasks\n  * None\n\n")
+      expect(subject.retrieve_release_notes('mysageone_uk','2.14.1')).to_not include("2.15")
+    end
+
+    it "returns a question mark if no content found for given paramaters" do
+      Octokit.stub_chain('contents','content').and_return(nil)
+      expect(subject.retrieve_release_notes('mysageone_uk','7000')).to eq("Could not retrieve release notes. Try again later.")
+    end
+
+    xit "configures filename and splitter for a given repo" do
+    end
+  end
+
+  describe :build_release_notes do
+    xit 'formats release notes correctly' do
+
+    end
+
+    xit 'returns message if no release notes found for an app version' do
+
+    end
+
+    xit 'returns stored version of release notes if release has status of Production' do
+
+    end
+
+    xit 'calls the retrieve_release_notes method if no release notes present' do
+
+    end
+    
+    xit 'calls the retrieve_release_notes method if release status not in Production' do
+
+    end
+  end
+end

--- a/spec/models/releases_spec.rb
+++ b/spec/models/releases_spec.rb
@@ -76,47 +76,4 @@ describe Release do
       expect(Release.sop_version('mysageone_uk', '2.14')).to eq('?')
     end
   end
-
-  describe :retrieve_release_notes do
-    before :each do
-      mysageone_uk_release_notes = Base64.encode64("# Version 2.15\n\n### Changes\n  * Allowing business access whilst business owner is blocked does not re-activated Zuora subscription [UKIEBUGS-366] (https://sageone.atlassian.net/browse/UKIEBUGS-366)\n  * Begin Rescue block when uploading mandate CSV to S3\n  * Fixes bug where client can not add new services if they only have collaborate [UKIEBUGS-322] (https://sageone.atlassian.net/browse/UKIEBUGS-322)\n  * Small change to remove variable assignment from rake datafixes:null_zuora_subscriptions\n  * Validate UK Bank Account Number on DD Form [UKIEBUGS-395] (https://sageone.atlassian.net/browse/UKIEBUGS-395)\n\n### Dependencies\n  * None\n\n### Deploy tasks\n  * None\n\n# Version 2.14.1\n\n### Changes\n  * Adding 'piwik' (new open source alternative to google analytics) tracking codes\n\n### Dependencies\n  * None\n\n### Deploy tasks\n  * None\n\n# Version 2.14\n\n### Changes\n  * Fixes Duplicate charges in Zuora after account un blocked [UKIEBUGS-138] (https://sageone.atlassian.net/browse/UKIEBUGS-138)\n  * Fixes calculation of next chargable date [UKIEBUGS-299] (https://sageone.atlassian.net/browse/UKIEBUGS-299)\n  * Fixes bug relating to downgrade from standard to cashbook with JWT [UKIEBUGS-315] (https://sageone.atlassian.net/browse/UKIEBUGS-315)\n  * Fixes bug relating to upgrade from Cashbook to Accounts when previously had the service [UKIEBUGS-318] (https://sageone.atlassian.net/browse/UKIEBUGS-318)\n  * Fixes bug relating to downgrading to Accounts when has previously has Cashbook and Accounts Extra via JWT [UKIEBUGS-321] (https://sageone.atlassian.net/browse/UKIEBUGS-321)\n  * Resolve an issue with Zuora subscription by running null_zuora_subscriptions rake task [UKIEBUGS-314] (https://sageone-uat.sageone.biz/browse/UKIEBUGS-314)\n  * Adding 'piwik' (new open source alternative to google analytics) tracking codes\n\n### Dependencies\n  * None\n\n### Deploy tasks\n  * bundle exec rake datafixes:null_zuora_subscriptions['ca8b06cd3c23ea14f69dd816f90621c1']\n\n#")
-
-      Octokit.stub_chain('contents','content').and_return(mysageone_uk_release_notes)
-    end
-
-    it "returns release notes for the given repo and version" do
-      expect(Release.retrieve_release_notes('mysageone_uk','2.14.1')).to eq("2.14.1\n\n### Changes\n  * Adding 'piwik' (new open source alternative to google analytics) tracking codes\n\n### Dependencies\n  * None\n\n### Deploy tasks\n  * None\n\n")
-      expect(Release.retrieve_release_notes('mysageone_uk','2.14.1')).to_not include("2.15")
-    end
-
-    it "returns a question mark if no content found for given paramaters" do
-      Octokit.stub_chain('contents','content').and_return(nil)
-      expect(Release.retrieve_release_notes('mysageone_uk','7000')).to eq("Could not retrieve release notes. Try again later.")
-    end
-
-    xit "configures filename and splitter for a given repo" do
-    end
-  end
-
-  describe :build_release_notes do
-    xit 'formats release notes correctly' do
-
-    end
-
-    xit 'returns message if no release notes found for an app version' do
-
-    end
-
-    xit 'returns stored version of release notes if release has status of Production' do
-
-    end
-
-    xit 'calls the retrieve_release_notes method if no release notes present' do
-
-    end
-    
-    xit 'calls the retrieve_release_notes method if release status not in Production' do
-
-    end
-  end
 end

--- a/spec/models/releases_spec.rb
+++ b/spec/models/releases_spec.rb
@@ -77,7 +77,7 @@ describe Release do
     end
   end
 
-  describe :release_notes do
+  describe :retrieve_release_notes do
     before :each do
       mysageone_uk_release_notes = Base64.encode64("# Version 2.15\n\n### Changes\n  * Allowing business access whilst business owner is blocked does not re-activated Zuora subscription [UKIEBUGS-366] (https://sageone.atlassian.net/browse/UKIEBUGS-366)\n  * Begin Rescue block when uploading mandate CSV to S3\n  * Fixes bug where client can not add new services if they only have collaborate [UKIEBUGS-322] (https://sageone.atlassian.net/browse/UKIEBUGS-322)\n  * Small change to remove variable assignment from rake datafixes:null_zuora_subscriptions\n  * Validate UK Bank Account Number on DD Form [UKIEBUGS-395] (https://sageone.atlassian.net/browse/UKIEBUGS-395)\n\n### Dependencies\n  * None\n\n### Deploy tasks\n  * None\n\n# Version 2.14.1\n\n### Changes\n  * Adding 'piwik' (new open source alternative to google analytics) tracking codes\n\n### Dependencies\n  * None\n\n### Deploy tasks\n  * None\n\n# Version 2.14\n\n### Changes\n  * Fixes Duplicate charges in Zuora after account un blocked [UKIEBUGS-138] (https://sageone.atlassian.net/browse/UKIEBUGS-138)\n  * Fixes calculation of next chargable date [UKIEBUGS-299] (https://sageone.atlassian.net/browse/UKIEBUGS-299)\n  * Fixes bug relating to downgrade from standard to cashbook with JWT [UKIEBUGS-315] (https://sageone.atlassian.net/browse/UKIEBUGS-315)\n  * Fixes bug relating to upgrade from Cashbook to Accounts when previously had the service [UKIEBUGS-318] (https://sageone.atlassian.net/browse/UKIEBUGS-318)\n  * Fixes bug relating to downgrading to Accounts when has previously has Cashbook and Accounts Extra via JWT [UKIEBUGS-321] (https://sageone.atlassian.net/browse/UKIEBUGS-321)\n  * Resolve an issue with Zuora subscription by running null_zuora_subscriptions rake task [UKIEBUGS-314] (https://sageone-uat.sageone.biz/browse/UKIEBUGS-314)\n  * Adding 'piwik' (new open source alternative to google analytics) tracking codes\n\n### Dependencies\n  * None\n\n### Deploy tasks\n  * bundle exec rake datafixes:null_zuora_subscriptions['ca8b06cd3c23ea14f69dd816f90621c1']\n\n#")
 
@@ -85,16 +85,38 @@ describe Release do
     end
 
     it "returns release notes for the given repo and version" do
-      expect(Release.release_notes('mysageone_uk','2.14.1')).to eq("2.14.1\n\n### Changes\n  * Adding 'piwik' (new open source alternative to google analytics) tracking codes\n\n### Dependencies\n  * None\n\n### Deploy tasks\n  * None\n\n")
-      expect(Release.release_notes('mysageone_uk','2.14.1')).to_not include("2.15")
+      expect(Release.retrieve_release_notes('mysageone_uk','2.14.1')).to eq("2.14.1\n\n### Changes\n  * Adding 'piwik' (new open source alternative to google analytics) tracking codes\n\n### Dependencies\n  * None\n\n### Deploy tasks\n  * None\n\n")
+      expect(Release.retrieve_release_notes('mysageone_uk','2.14.1')).to_not include("2.15")
     end
 
     it "returns a question mark if no content found for given paramaters" do
       Octokit.stub_chain('contents','content').and_return(nil)
-      expect(Release.release_notes('mysageone_uk','7000')).to eq("?")
+      expect(Release.retrieve_release_notes('mysageone_uk','7000')).to eq("Could not retrieve release notes. Try again later.")
     end
 
     xit "configures filename and splitter for a given repo" do
+    end
+  end
+
+  describe :build_release_notes do
+    xit 'formats release notes correctly' do
+
+    end
+
+    xit 'returns message if no release notes found for an app version' do
+
+    end
+
+    xit 'returns stored version of release notes if release has status of Production' do
+
+    end
+
+    xit 'calls the retrieve_release_notes method if no release notes present' do
+
+    end
+    
+    xit 'calls the retrieve_release_notes method if release status not in Production' do
+
     end
   end
 end


### PR DESCRIPTION
Pending Specs will be addressed later.

This moves release notes into it's own model making it easier to maintain. It also cache's release notes from github, so when the release goes to production it no longer needs to query github.
